### PR TITLE
In-cart rewards setup

### DIFF
--- a/assets/theme.scss.liquid
+++ b/assets/theme.scss.liquid
@@ -5821,3 +5821,182 @@ $toolbar-height-small: 46px;
   font-size: em(floor($font-size-base * 0.88));
 }
 
+/*================ LoyaltyLion ================*/
+
+$color-grey: #e8e9eb;
+
+.cart-with-rewards {
+  display: flex;
+}
+
+.cart-with-rewards__cart {
+  flex-grow: 1;
+  border-right: 1px solid $color-grey;
+  padding-right: 2em;
+}
+
+.cart-with-rewards__widget {
+  padding-left: 2em;
+  width: 300px;
+}
+
+.loyaltylion-redemption-widget-container {
+  width: 100%;
+  text-align: center;
+  margin-bottom: 20px;
+
+  & > h2 {
+    margin-bottom: 3px;
+  }
+}
+
+.loyaltylion-redemption-widget--disabled {
+  opacity: 0.5;
+  pointer-events: none;
+}
+
+.loyaltylion-redemption-widget__header {
+  background-color: #fff;
+  padding: 13px 0;
+}
+
+.loyaltylion-redemption-widget__guest {
+  padding-top: 2em;
+
+  & > a {
+    text-decoration: underline;
+  }
+}
+
+.loyaltylion-redemption-widget__points {
+  font-weight: bold;
+}
+
+.loyaltylion-redemption-widget__lead {
+  margin-bottom: 0;
+  position: relative;
+}
+
+.loyaltylion-redemption-widget-rewards {
+  border-top: 1px solid;
+  border-bottom: 1px solid;
+  border-color: $color-grey;
+  background-color: #fcfcfc;
+  position: relative;
+  overflow: hidden;
+  max-height: 300px;
+  transition: max-height 0.15s ease-in-out;
+}
+
+.loyaltylion-redemption-widget-rewards--hidden {
+  max-height: 0;
+}
+
+.loyaltylion-redemption-widget__navigator {
+  display: block;
+  position: absolute;
+  border-radius: 100%;
+  width: 30px;
+  height: 30px;
+  line-height: 24px;
+  font-size: 42px;
+  color: #333;
+  top: 50%;
+  margin-top: -15px;
+}
+
+.loyaltylion-redemption-widget__navigator--hidden {
+  display: none;
+}
+
+.loyaltylion-redemption-widget__navigator--back {
+  left: -5px;
+}
+
+.loyaltylion-redemption-widget__navigator--forward {
+  right: -5px;
+}
+
+.loyaltylion-redemption-widget__rewards-slider {
+  display: flex;
+  position: relative;
+  transition: left 0.25s cubic-bezier(0.23, 1, 0.32, 1);
+}
+
+.loyaltylion-product-reward {
+  flex: 0 0 100%;
+  flex-basis: 100%;
+  padding: 20px 0;
+  display: flex;
+  flex-direction: column;
+}
+
+.loyaltylion-product-reward__picture img {
+  height: 100px;
+  box-shadow: 0px 0px 14px 0px rgba(201, 201, 201, 0.3);
+  margin-bottom: 5px;
+}
+
+.loyaltylion-product-reward__cost {
+  margin-bottom: 12px;
+  display: none;
+}
+
+.loyaltylion-product-reward__name {
+  font-weight: bold;
+  margin-bottom: 15px;
+  font-size: 110%;
+  flex-grow: 1;
+}
+
+.loyaltylion-product-reward__variant-selector {
+  display: none;
+}
+
+/* loading spinner for the button */
+
+@keyframes redemption-widget-spinner {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.loyaltylion-product-reward__button[data-lion-working] {
+  position: relative;
+  color: transparent;
+}
+
+.loyaltylion-product-reward__button[data-lion-working]:before {
+  content: '';
+  box-sizing: border-box;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 20px;
+  height: 20px;
+  margin-top: -10px;
+  margin-left: -10px;
+  border-radius: 50%;
+  border-top: 2px solid #fff;
+  border-right: 2px solid transparent;
+  animation: redemption-widget-spinner .7s linear infinite;
+}
+
+@media only screen and (max-width: 650px) {
+  .cart-with-rewards {
+    display: block;
+  }
+
+  .cart-with-rewards__cart {
+    padding-right: 0;
+    border-right: none;
+    border-bottom: 1px solid $color-grey;
+    padding-bottom: 2em;
+  }
+
+  .cart-with-rewards__widget {
+    padding-left: 0;
+    padding-top: 2em;
+    width: 100%;
+  }
+}

--- a/sections/cart-template.liquid
+++ b/sections/cart-template.liquid
@@ -145,6 +145,7 @@
         </form>
       </div>
       <div class="cart-with-rewards__widget">
+        {% include 'loyaltylion-cart-widget' %}
       </div>
     </div>
   {% else %}

--- a/sections/collection-template.liquid
+++ b/sections/collection-template.liquid
@@ -153,6 +153,9 @@
 
       <div class="grid grid--uniform{% if collection.products_count > 0 %} grid--view-items{% endif %}">
         {% for product in collection.products %}
+          {% if product.tags contains 'reward' %}
+            {% continue %}
+          {% endif %}
           <div class="grid__item grid__item--{{section.id}} {{ grid_item_width }}">
             {% include 'product-card-grid', max_height: max_height %}
           </div>

--- a/sections/collection-template.liquid
+++ b/sections/collection-template.liquid
@@ -77,6 +77,9 @@
                     {% endif %}
                   {% endif %}
                   {% for tag in collection.all_tags %}
+                    {% if tag == 'reward' or tag == 'loyaltylion' %}
+                      {% continue %}
+                    {% endif %}
                     <option value="/collections/{% if collection.handle != blank %}{{ collection.handle }}{% else %}all{% endif %}/{{ tag | handleize }}"{% if current_tags contains tag %} selected="selected"{% endif %}>{{ tag }}</option>
                   {% endfor %}
                 </select>

--- a/sections/product-template.liquid
+++ b/sections/product-template.liquid
@@ -138,6 +138,7 @@
             {% endif %}
           </p>
 
+          {% unless product.tags contains 'reward' %}
           <form action="/cart/add" method="post" enctype="multipart/form-data" class="product-form product-form-{{ section.id }}{% unless section.settings.show_variant_labels %} product-form--hide-variant-labels{% endunless %}" data-section="{{ section.id }}">
             {% unless product.has_only_default_variant %}
               {% for option in product.options_with_values %}
@@ -185,6 +186,7 @@
               </button>
             </div>
           </form>
+          {% endunless %}
 
         </div>
 

--- a/snippets/loyaltylion-cart-widget.liquid
+++ b/snippets/loyaltylion-cart-widget.liquid
@@ -1,0 +1,30 @@
+<div class='loyaltylion-redemption-widget-container'>
+  <h2>Redeem your points</h2>
+  {% if customer %}
+    <div class="loyaltylion-redemption-widget__header">
+      <div class="loyaltylion-redemption-widget__lead">
+        You can redeem <span class="loyaltylion-redemption-widget__points" data-lion-points="cart"></span> points
+      </div>
+    </div>
+    <div class='loyaltylion-redemption-widget-rewards'>
+      <div data-lion-seamless-product-reward-widget></div>
+    </div>
+  {% else %}
+    <div class="loyaltylion-redemption-widget__guest">
+      Please <a href='/account/login'>log in</a> or <a href='/account/register'>sign up</a> to redeem points for rewards
+    </div>
+  {% endif %}
+</div>
+
+<script>
+  // LoyaltyLion fires this event any time it adds or removes
+  // an item from cart; as we don't have an Ajax cart we'll
+  // refresh the page instead.
+  //
+  // if you do have an Ajax cart, you'll want to listen to this event
+  // and re-render your cart when it's emitted
+
+  lion.on('cart.changed', function() {
+    window.location.reload()
+  })
+</script>

--- a/templates/search.liquid
+++ b/templates/search.liquid
@@ -42,6 +42,9 @@
   {% endif %}
   <div class="page-width list-view-items">
     {% for item in search.results %}
+      {% if item.tags contains 'reward' %}
+        {% continue %}
+      {% endif %}
       <a href="{{ item.url }}" class="list-view-item">
         {% if item.object_type == 'product' %}
           {% include 'product-card-list', product: item %}


### PR DESCRIPTION
This pull request shows a straightforward integration of in-cart rewards into the default Shopify theme.

* hiding reward products from search results and /collections/all
* hiding the `reward` and `loyaltylion` tags from the list of tags
* preventing reward products from being added to the cart from product pages
* adding the "redemption widget" to the cart page with reference styles